### PR TITLE
Update initSettings.sqf

### DIFF
--- a/addons/viewdistance/initSettings.sqf
+++ b/addons/viewdistance/initSettings.sqf
@@ -5,14 +5,14 @@ private _category = format ["ACE %1", localize LSTRING(Module_DisplayName)];
     [LSTRING(enabled_DisplayName), LSTRING(enabled_Description)],
     _category,
     true,
-    1
+    0
 ] call CBA_fnc_addSetting;
 
 [
     QGVAR(viewDistanceOnFoot), "SLIDER",
     [LSTRING(onFoot_DisplayName), format ["%1\n%2", LLSTRING(onFoot_Description), LLSTRING(sliderExtraDescription)]],
     _category,
-    [0, 10000, 0, -1],
+    [0, 40000, 0, -1],
     0,
     {[true] call FUNC(adaptViewDistance)}
 ] call CBA_fnc_addSetting;
@@ -21,7 +21,7 @@ private _category = format ["ACE %1", localize LSTRING(Module_DisplayName)];
     QGVAR(viewDistanceLandVehicle), "SLIDER",
     [LSTRING(landVehicle_DisplayName), format ["%1\n%2", LLSTRING(landVehicle_Description), LLSTRING(sliderExtraDescription)]],
     _category,
-    [0, 10000, 0, -1],
+    [0, 40000, 0, -1],
     0,
     {[true] call FUNC(adaptViewDistance)}
 ] call CBA_fnc_addSetting;
@@ -30,7 +30,7 @@ private _category = format ["ACE %1", localize LSTRING(Module_DisplayName)];
     QGVAR(viewDistanceAirVehicle), "SLIDER",
     [LSTRING(airVehicle_DisplayName), format ["%1\n%2", LLSTRING(airVehicle_Description), LLSTRING(sliderExtraDescription)]],
     _category,
-    [0, 10000, 0, -1],
+    [0, 40000, 0, -1],
     0,
     {[true] call FUNC(adaptViewDistance)}
 ] call CBA_fnc_addSetting;
@@ -39,8 +39,8 @@ private _category = format ["ACE %1", localize LSTRING(Module_DisplayName)];
     QGVAR(limitViewDistance), "SLIDER",
     [LSTRING(limit_DisplayName), LSTRING(limit_setting)],
     _category,
-    [500, 12000, 10000, -1],
-    1,
+    [500, 40000, 10000, -1],
+    0,
     {[true] call FUNC(adaptViewDistance)}
 ] call CBA_fnc_addSetting;
 
@@ -48,7 +48,7 @@ private _category = format ["ACE %1", localize LSTRING(Module_DisplayName)];
     QGVAR(objectViewDistanceCoeff), "LIST",
     [LSTRING(object_DisplayName), LSTRING(object_Description)],
     _category,
-    [[0, 1, 2, 3, 4, 5, 6], [LSTRING(object_off), LSTRING(object_verylow), LSTRING(object_low), LSTRING(object_medium),LSTRING(object_high), LSTRING(object_veryhigh), LSTRING(object_fovBased)], 0],
+    [[0, 1, 2, 3, 4, 5, 6], [LSTRING(object_off), LSTRING(object_verylow), LSTRING(object_low), LSTRING(object_medium),LSTRING(object_high), LSTRING(object_veryhigh), LSTRING(object_fovBased)], 6],
     0,
     {[true] call FUNC(adaptViewDistance)}
 ] call CBA_fnc_addSetting;


### PR DESCRIPTION
- Allowed for always server forced settings to not be server forced (allwoing mission forcing, otherwise its clients choice).
- increase maximum distance options avaialble to what vanilla now supports (ace had it at 10k, vanilla was 12k, its now all 40k)
- set the defualt setting for dunamic view disatnce to FOV (needs testing, but geenrally this setting is OP. tighter FOV usually increase framerate, and this increases object distance such that framerate remains somewhat the same. FOV = zoom)