### PR TITLE
Viewdistance initSettings.inc.sqf Update 2

### DIFF
--- a/addons/medical_feedback/functions/fnc_effectBloodVolume.sqf
+++ b/addons/medical_feedback/functions/fnc_effectBloodVolume.sqf
@@ -24,5 +24,5 @@ if ((!_enable) || {_intensity == 0}) exitWith {
 };
 
 GVAR(ppBloodVolume) ppEffectEnable true;
-GVAR(ppBloodVolume) ppEffectAdjust [1, 1, 0, [0, 0, 0, 0],  [1, 1, 1, 1 - _intensity],  [0.2, 0.2, 0.2, 0]];
+GVAR(ppBloodVolume) ppEffectAdjust [1, (1-_intensity), 0, [0, 0, 0, _intensity],  [(1+(_intensity*2)), 1, 1, (1 - _intensity)],  [4, -1.5, -1.5, 0]];
 GVAR(ppBloodVolume) ppEffectCommit 1;

--- a/addons/viewdistance/initSettings.inc.sqf
+++ b/addons/viewdistance/initSettings.inc.sqf
@@ -12,7 +12,7 @@ private _category = format ["ACE %1", localize LSTRING(Module_DisplayName)];
     QGVAR(viewDistanceOnFoot), "SLIDER",
     [LSTRING(onFoot_DisplayName), format ["%1\n%2", LLSTRING(onFoot_Description), LLSTRING(sliderExtraDescription)]],
     _category,
-    [0, 40000, 0, -1],
+    [0, 20000, 0, -1],
     0,
     {[true] call FUNC(adaptViewDistance)}
 ] call CBA_fnc_addSetting;
@@ -21,7 +21,7 @@ private _category = format ["ACE %1", localize LSTRING(Module_DisplayName)];
     QGVAR(viewDistanceLandVehicle), "SLIDER",
     [LSTRING(landVehicle_DisplayName), format ["%1\n%2", LLSTRING(landVehicle_Description), LLSTRING(sliderExtraDescription)]],
     _category,
-    [0, 40000, 0, -1],
+    [0, 20000, 0, -1],
     0,
     {[true] call FUNC(adaptViewDistance)}
 ] call CBA_fnc_addSetting;
@@ -30,7 +30,7 @@ private _category = format ["ACE %1", localize LSTRING(Module_DisplayName)];
     QGVAR(viewDistanceAirVehicle), "SLIDER",
     [LSTRING(airVehicle_DisplayName), format ["%1\n%2", LLSTRING(airVehicle_Description), LLSTRING(sliderExtraDescription)]],
     _category,
-    [0, 40000, 0, -1],
+    [0, 20000, 0, -1],
     0,
     {[true] call FUNC(adaptViewDistance)}
 ] call CBA_fnc_addSetting;
@@ -39,7 +39,7 @@ private _category = format ["ACE %1", localize LSTRING(Module_DisplayName)];
     QGVAR(limitViewDistance), "SLIDER",
     [LSTRING(limit_DisplayName), LSTRING(limit_setting)],
     _category,
-    [500, 40000, 10000, -1],
+    [500, 20000, 10000, -1],
     0,
     {[true] call FUNC(adaptViewDistance)}
 ] call CBA_fnc_addSetting;


### PR DESCRIPTION
After testing every map in the curret repo. 'Some' maps crash instantly with values over 35k.
One map (MOUT TRaining) crashes over ~22k~. (if only we didndt have this one map, wink wink)
Vanilla was 12k, and ACE origional max is 10k.
So ive dropped the maxes down to 20k. Which is still double what we got now. but shouldnt cause crashing on any map and realistically is more then enough for most desired effects.
